### PR TITLE
Clear and focus otp input on error and various improvements on post-transfer experience

### DIFF
--- a/code/client/src/components/OtpBox.jsx
+++ b/code/client/src/components/OtpBox.jsx
@@ -1,13 +1,14 @@
 import OtpInput from 'react-otp-input'
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { useWindowDimensions } from '../util'
 
-const OtpBox = ({ onChange, value, inputStyle, ...params }) => {
+const OtpBox = ({ onChange, value, inputStyle, ...params }, ref) => {
   const { isMobile } = useWindowDimensions()
   return (
     <OtpInput
       placeholder=''
       value={value}
+      ref={ref}
       onChange={onChange}
       numInputs={6}
       inputStyle={{ width: isMobile ? 24 : 32, borderRadius: 8, borderWidth: 1, height: isMobile ? 24 : 32, fontSize: isMobile ? 12 : 16, marginRight: isMobile ? 8 : 16, ...inputStyle }}
@@ -17,4 +18,4 @@ const OtpBox = ({ onChange, value, inputStyle, ...params }) => {
   )
 }
 
-export default OtpBox
+export default forwardRef(OtpBox)

--- a/code/client/src/pages/Create.jsx
+++ b/code/client/src/pages/Create.jsx
@@ -20,7 +20,6 @@ import { handleAPIError, handleAddressError } from '../handler'
 import { Hint, Heading, InputBox } from '../components/Text'
 import OtpBox from '../components/OtpBox'
 import { getAddress } from '@harmony-js/crypto'
-import OtpInput from 'react-otp-input'
 const { Text, Link } = Typography
 
 // const genName = () => uniqueNamesGenerator({

--- a/code/client/src/pages/Create.jsx
+++ b/code/client/src/pages/Create.jsx
@@ -20,6 +20,7 @@ import { handleAPIError, handleAddressError } from '../handler'
 import { Hint, Heading, InputBox } from '../components/Text'
 import OtpBox from '../components/OtpBox'
 import { getAddress } from '@harmony-js/crypto'
+import OtpInput from 'react-otp-input'
 const { Text, Link } = Typography
 
 // const genName = () => uniqueNamesGenerator({
@@ -100,6 +101,8 @@ const Create = () => {
     if (code.padStart(6, '0') !== otp.padStart(6, '0')) {
       console.log(`Expected: ${code}. Got: ${otp}`)
       message.error('Code is incorrect. Please try again.')
+      setOtp('')
+      try { document.getElementsByClassName('otpInput')[0].getElementsByTagName('input')[0].focus() } catch (e) {}
     } else {
       setSection(3)
     }
@@ -233,6 +236,7 @@ const Create = () => {
             <Hint>After you are done, type in the 6-digit code from Google authenticator.</Hint>
             <OtpBox
               shouldAutoFocus
+              containerStyle='otpInput'
               value={otp}
               onChange={setOtp}
             />

--- a/code/client/src/pages/Create.jsx
+++ b/code/client/src/pages/Create.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory } from 'react-router'
 import Paths from '../constants/paths'
@@ -68,6 +68,8 @@ const Create = () => {
 
   const [deploying, setDeploying] = useState()
 
+  const otpRef = useRef()
+
   const getQRCodeUri = () => {
     // otpauth://TYPE/LABEL?PARAMETERS
     return `otpauth://totp/${name}?secret=${b32.encode(seed)}&issuer=Harmony`
@@ -101,7 +103,7 @@ const Create = () => {
       console.log(`Expected: ${code}. Got: ${otp}`)
       message.error('Code is incorrect. Please try again.')
       setOtp('')
-      try { document.getElementsByClassName('otpInput')[0].getElementsByTagName('input')[0].focus() } catch (e) {}
+      otpRef?.current?.focusInput(0)
     } else {
       setSection(3)
     }
@@ -235,7 +237,7 @@ const Create = () => {
             <Hint>After you are done, type in the 6-digit code from Google authenticator.</Hint>
             <OtpBox
               shouldAutoFocus
-              containerStyle='otpInput'
+              ref={otpRef}
               value={otp}
               onChange={setOtp}
             />

--- a/code/client/src/pages/Show.jsx
+++ b/code/client/src/pages/Show.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, memo, useRef } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory, useRouteMatch, Redirect, useLocation, matchPath } from 'react-router'
 import Paths from '../constants/paths'
@@ -15,7 +15,8 @@ import {
   WarningOutlined,
   CloseOutlined,
   QuestionCircleOutlined,
-  LoadingOutlined
+  LoadingOutlined,
+  CheckCircleOutlined
 } from '@ant-design/icons'
 // import styled from 'styled-components'
 import humanizeDuration from 'humanize-duration'
@@ -217,7 +218,7 @@ const Show = () => {
     } else {
       message.success(<Text>Transfer completed! Copy transaction id: <Text copyable={{ text: txId }}>{util.ellipsisAddress(txId)} </Text></Text>, 10)
     }
-    resetOtp()
+    setTimeout(restart, 3000)
   }
 
   const doSend = async () => {
@@ -497,8 +498,8 @@ const Show = () => {
         <Row justify='end' style={{ marginTop: 24 }}>
           <Space>
             {stage > 0 && stage < 3 && <LoadingOutlined />}
-            {stage < 3 && <Button type='primary' size='large' shape='round' disabled={stage > 0} onClick={doSend}>Send</Button>}
-            {stage === 3 && <Button type='secondary' size='large' shape='round' onClick={restart}>Restart</Button>}
+            {stage === 3 && <CheckCircleOutlined />}
+            <Button type='primary' size='large' shape='round' disabled={stage > 0} onClick={doSend}>Send</Button>
           </Space>
         </Row>
         <CommitRevealProgress stage={stage} style={{ marginTop: 32 }} />


### PR DESCRIPTION
The only place I could find where clearing and focusing made sense was on wallet creation. Transfer check happens later and it seems inputs are cleared anyway. Restore has no user input from what I can tell?

`react-otp-input` doesn't seem to have a method for focusing to the first input so I had to do it with vanilla JS selectors.