### PR TITLE
Deploy 1wallet to Skynet

### DIFF
--- a/.github/workflows/deploy-wallet-to-skynet.yml
+++ b/.github/workflows/deploy-wallet-to-skynet.yml
@@ -1,0 +1,34 @@
+name: Deploy wallet to Skynet
+
+on:
+  pull_request:
+    paths:
+      - code/client/**
+      - scripts/hdnode.js
+  push:
+    branches:
+      - master
+    paths:
+      - code/client/**
+      - scripts/hdnode.js
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+
+      - run: scripts/setup.sh
+      - run: yarn build
+        working-directory: code/client
+
+      - name: Deploy to Skynet
+        uses: skynetlabs/deploy-to-skynet-action@v2
+        with:
+          upload-dir: code/client/dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          registry-seed: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && secrets.SKYNET_WALLET_REGISTRY_SEED || '' }}

--- a/.github/workflows/deploy-wallet-to-skynet.yml
+++ b/.github/workflows/deploy-wallet-to-skynet.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - code/client/**
+      - code/yarn.lock
       - scripts/hdnode.js
   push:
     branches:
       - master
     paths:
       - code/client/**
+      - code/yarn.lock
       - scripts/hdnode.js
 
 jobs:


### PR DESCRIPTION
This pull request adds [Deploy to Skynet](https://github.com/marketplace/actions/skynet-deploy) github action integration for deploying 1wallet to [Skynet](https://siasky.net/) decentralised cloud storage. It works automatically, detecting pushed changes to wallet related paths.

This pull request relies on github actions. In a case where github actions are not preferred solution, I can provide a manual drop in deploy script that does the same thing although it will require the maintainer to run it potentially on every release.

Example deploy: [04052te3b2jhcugo7e03rabhpjd3ps8n8dmfm8md885pa9u6aof1850](https://04052te3b2jhcugo7e03rabhpjd3ps8n8dmfm8md885pa9u6aof1850.siasky.net/)

### maintainer follow ups

1. github actions have to be enabled for the repository
1. maintainer should add `SKYNET_WALLET_REGISTRY_SEED` secret to github which will act as a deploy key
    - it has to be cryptographically secure - it will be used to sign all of your deploys to Skynet
    - we recommend either generating it yourself or using one of the random ones from an online generator ie. https://randomkeygen.com/
    - the key can be changed at any time but your resolver skylink (hash for latest deploy) will change so users will need to manually switch to new url
1. once this pull request is merged (steps 1 and 2 should be completed prior to that), github will be set to automatically run an action on change to any wallet related code that takes the latest master branch, builds wallet and deploys it to Skynet. For the first time only, maintainer will need to open the action logs and copy "Resolver Skylink Url" from "Deploy to Skynet" step once it's completed (see [example output](https://github.com/SkynetLabs/homescreen/runs/3906612726) from one of our own repositories). This url will stay the same after each deploy so you can share it with your users, I usually recommend a small note in README.md.
   - a note here: github action will only run on changes to either `code/client/**` or `scripts/hdnode.js` so to trigger it for the first time I recommend doing a small change inside of any file in `code/client/**` for example add a new line somewhere or use this opportunity to update some npm dependencies; on that note, the yml action configuration file can be also adjusted to trigger on different events so let me know if that's something that you would be interested in adjusting

### homescreen integration

Once wallet is successfully set to deploy to Skynet, it is highly recommended to also add support for [Homescreen](https://homescreen.hns.siasky.net) users (please read more at our homescreen webpage about the advantages it brings). It only consists of two steps:
1. update manifest.json by adding a skylink key `"skylink": "<55_character_resolver_skylink_here>"` - skylink is the 46 or 55 character part of the url (subdomain) from point 3 of previous section ([example commit](https://github.com/kwypchlo/note-to-self/commit/9764549520a90c8b58b4b3fb400a3bf330010171)) - unfortunately 1wallet doesn't have manifest file yet so in any case it is recommended to add one according to the spec https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json and link it in index.html file so it can be discovered by browsers
2. add a badge to your readme so users can easily click to add wallet to homescreen ([example commit](https://github.com/kwypchlo/note-to-self/commit/7ce582df6eff1a7fbc367a4cc0fb7489ec481e14)) with markdown code (replace skylink with the resolver skylink from the manifest)
```md
[![Add to Homescreen](https://img.shields.io/badge/Skynet-Add%20To%20Homescreen-00c65e?logo=skynet&labelColor=0d0d0d)](https://homescreen.hns.siasky.net/#/skylink/<skylink-here>)
```

---

Let me know if there are any questions or concerns you would like to have addressed! I hope the integration goes smooth and easy :)