### PR TITLE
add decimals for default known erc20 tokens

### DIFF
--- a/code/client/src/components/TokenAssets.jsx
+++ b/code/client/src/components/TokenAssets.jsx
@@ -18,24 +18,28 @@ export const KnownERC20 = {
     icon: IconETH,
     symbol: '1ETH',
     name: 'Ethereum ETH',
+    decimals: 18,
     contractAddress: '0x6983D1E6DEf3690C4d616b13597A09e6193EA013'
   },
   '1WBTC': {
     icon: IconBTC,
     symbol: '1WBTC',
     name: 'Wrapped BTC',
+    decimals: 6,
     contractAddress: '0x3095c7557bCb296ccc6e363DE01b760bA031F2d9'
   },
   '1USDC': {
     icon: IconUSDC,
     symbol: '1USDC',
     name: 'USD Coin',
+    decimals: 6,
     contractAddress: '0x985458E523dB3d53125813eD68c274899e9DfAb4'
   },
   BUSD: {
     icon: IconBUSD,
     symbol: 'BUSD',
     name: 'Binance USD',
+    decimals: 18,
     contractAddress: '0xE176EBE47d621b984a73036B9DA5d834411ef734'
   },
   USDT: {
@@ -49,30 +53,35 @@ export const KnownERC20 = {
     icon: IconBNB,
     symbol: 'bscBUSD',
     name: 'BUSD Token',
+    decimals: 18,
     contractAddress: '0x0aB43550A6915F9f67d0c454C2E90385E6497EaA'
   },
   '1SUSHI': {
     icon: IconSushi,
     symbol: '1SUSHI',
     name: 'SushiToken',
+    decimals: 18,
     contractAddress: '0xBEC775Cb42AbFa4288dE81F387a9b1A3c4Bc552A'
   },
   '1DAI': {
     icon: IconDAI,
     symbol: '1DAI',
     name: 'Dai Stablecoin',
+    decimals: 18,
     contractAddress: '0xEf977d2f931C1978Db5F6747666fa1eACB0d0339'
   },
   '1AAVE': {
     icon: IconAAVE,
     symbol: '1AAVE',
     name: 'Aave Token',
+    decimals: 18,
     contractAddress: '0xcF323Aad9E522B93F11c352CaA519Ad0E14eB40F'
   },
   bscUSDT: {
     icon: IconUSDT,
     symbol: 'bscUSDT',
     name: 'Binance USDT',
+    decimals: 18,
     contractAddress: '0x9a89d0e1b051640c6704dde4df881f73adfef39a'
   },
 }
@@ -91,13 +100,14 @@ export const DefaultTrackedERC20 = network => {
     return []
   }
   return Object.keys(KnownERC20).map(symbol => {
-    const { contractAddress, icon, name } = KnownERC20[symbol]
+    const { contractAddress, icon, name, decimals } = KnownERC20[symbol]
     return {
       tokenType: ONEConstants.TokenType.ERC20,
       tokenId: 0,
       contractAddress,
       icon,
       name,
+      decimals,
       symbol,
     }
   })

--- a/code/client/src/pages/Show/Swap.jsx
+++ b/code/client/src/pages/Show/Swap.jsx
@@ -208,7 +208,8 @@ const Swap = ({ address }) => {
       return
     }
     const erc20Tracked = (wallet.trackedTokens || []).filter(e => e.tokenType === ONEConstants.TokenType.ERC20)
-    const trackedTokens = [harmonyToken, ...withKeys(DefaultTrackedERC20(network)), ...(erc20Tracked || [])]
+    const trackedTokens = [harmonyToken, ...(erc20Tracked || [])]
+    console.log(trackedTokens)
     trackedTokens.forEach(tt => {
       // align formats
       tt.address = tt.address || tt.contractAddress

--- a/code/client/src/pages/Show/Swap.jsx
+++ b/code/client/src/pages/Show/Swap.jsx
@@ -208,8 +208,7 @@ const Swap = ({ address }) => {
       return
     }
     const erc20Tracked = (wallet.trackedTokens || []).filter(e => e.tokenType === ONEConstants.TokenType.ERC20)
-    const trackedTokens = [harmonyToken, ...(erc20Tracked || [])]
-    console.log(trackedTokens)
+    const trackedTokens = [harmonyToken, ...withKeys(DefaultTrackedERC20(network)), ...(erc20Tracked || [])]
     trackedTokens.forEach(tt => {
       // align formats
       tt.address = tt.address || tt.contractAddress

--- a/code/client/src/pages/Show/Swap.jsx
+++ b/code/client/src/pages/Show/Swap.jsx
@@ -208,7 +208,7 @@ const Swap = ({ address }) => {
       return
     }
     const erc20Tracked = (wallet.trackedTokens || []).filter(e => e.tokenType === ONEConstants.TokenType.ERC20)
-    const trackedTokens = [harmonyToken, ...withKeys(DefaultTrackedERC20(network)), ...(erc20Tracked || [])]
+    const trackedTokens = [harmonyToken, ...(erc20Tracked || []), ...withKeys(DefaultTrackedERC20(network))]
     trackedTokens.forEach(tt => {
       // align formats
       tt.address = tt.address || tt.contractAddress
@@ -223,8 +223,10 @@ const Swap = ({ address }) => {
         dispatch(walletActions.fetchTokenBalance({ address, tokenType, tokenId, contractAddress, key }))
       }
     })
+    const filteredTrackedTokens = [...new Map(trackedTokens.map(v => [v.address, v])).values()]
+
     const updateFromTokens = async () => {
-      const trackedTokensUpdated = await api.tokens.batchGetMetadata(trackedTokens)
+      const trackedTokensUpdated = await api.tokens.batchGetMetadata(filteredTrackedTokens)
       // ONE has null contractAddress
       const filteredTokens = trackedTokensUpdated.filter(t => t.contractAddress === null || tokens[t.contractAddress])
 


### PR DESCRIPTION
Removed default  tracked erc20 token

Reasons,
1. User doesn't have any tokens with those, if they do have some, it will be part of `erc20Tracked`
2. Those known erc20 token doesn't have decimals - https://github.com/polymorpher/one-wallet/blob/e9f8edc4c123fb104c159c7544a40806ee09aaed/code/client/src/components/TokenAssets.jsx#L16-L22

related #204 

